### PR TITLE
Bugfix: when null is sent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stubon",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "stubon is simple dummy api server.",
   "main": "index.js",
   "bin": {

--- a/src/stubon.js
+++ b/src/stubon.js
@@ -104,11 +104,11 @@ const privates = {
         if (typeof whole !== typeof part) {
             return false;
         }
-        if (Array.isArray(part)) {
+        if (Array.isArray(whole) && Array.isArray(part)) {
             return part.sort().every(
                 (val, index) => privates.isSubsetObject(whole[index], val),
             );
-        } else if (part instanceof Object) {
+        } else if (whole instanceof Object && part instanceof Object) {
             return Object.keys(part).every(
                 key => privates.isSubsetObject(whole[key], part[key]),
             );

--- a/test/method.spec.js
+++ b/test/method.spec.js
@@ -104,6 +104,15 @@ describe('src/stubon.js privates.isSubsetObject', () => {
             },
             expected : false,
         },
+        'false : Can also determine null' : {
+            whole : {
+                hogeArray : null,
+            },
+            part : {
+                hogeArray : [1],
+            },
+            expected : false,
+        },
         'various types of values and multi-level object' : {
             whole : {
                 vStr    : 'str',


### PR DESCRIPTION
If null is multiplied by typeof, it becomes 'object', but that consideration has been leaked out.